### PR TITLE
feat: expose slot fill presence to context as `{{ slots.<slot_name> }}`

### DIFF
--- a/docs/slot_rendering.md
+++ b/docs/slot_rendering.md
@@ -1,0 +1,238 @@
+# Slot rendering
+
+This doc serves as a primer on how component slots and fills are resolved.
+
+## Flow
+
+1. Imagine you have a template. Some kind of text, maybe HTML:
+   ```django
+   | ------
+   | ---------
+   | ----
+   | -------
+   ```
+
+2. The template may contain some vars, tags, etc
+   ```django
+   | -- {{ my_var }} --
+   | ---------
+   | ----
+   | -------
+   ```
+
+3. The template also contains some slots, etc
+   ```django
+   | -- {{ my_var }} --
+   | ---------
+   | -- {% slot "myslot" %} ---
+   | -- {% endslot %} ---
+   | ----
+   | -- {% slot "myslot2" %} ---
+   | -- {% endslot %} ---
+   | -------
+   ```
+
+4. Slots may be nested
+   ```django
+   | -- {{ my_var }} --
+   | -- ABC
+   | -- {% slot "myslot" %} ---
+   | ----- DEF {{ my_var }}
+   | ----- {% slot "myslot_inner" %}
+   | -------- GHI {{ my_var }}
+   | ----- {% endslot %}
+   | -- {% endslot %} ---
+   | ----
+   | -- {% slot "myslot2" %} ---
+   | ---- JKL {{ my_var }}
+   | -- {% endslot %} ---
+   | -------
+   ```
+
+5. Some slots may be inside fills for other components
+   ```django
+   | -- {{ my_var }} --
+   | -- ABC
+   | -- {% slot "myslot" %}---
+   | ----- DEF {{ my_var }}
+   | ----- {% slot "myslot_inner" %}
+   | -------- GHI {{ my_var }}
+   | ----- {% endslot %}
+   | -- {% endslot %} ---
+   | ------
+   | -- {% component "mycomp" %} ---
+   | ---- {% slot "myslot" %} ---
+   | ------- JKL {{ my_var }}
+   | ------- {% slot "myslot_inner" %}
+   | ---------- MNO {{ my_var }}
+   | ------- {% endslot %}
+   | ---- {% endslot %} ---
+   | -- {% endcomponent %} ---
+   | ----
+   | -- {% slot "myslot2" %} ---
+   | ---- PQR {{ my_var }}
+   | -- {% endslot %} ---
+   | -------
+   ```
+
+5. I want to render the slots with `{% fill %}` tag that were defined OUTSIDE of this template. How do I do that?
+
+   1. Traverse the template to collect ALL slots
+      - NOTE: I will also look inside `{% slot %}` and `{% fill %}` tags, since they are all still
+      defined within the same TEMPLATE.
+    
+      I should end up with a list like this:
+      ```txt
+      - Name: "myslot"
+         ID 0001
+         Content:
+         | ----- DEF {{ my_var }}
+         | ----- {% slot "myslot_inner" %}
+         | -------- GHI {{ my_var }}
+         | ----- {% endslot %}
+      - Name: "myslot_inner"
+         ID 0002
+         Content:
+         | -------- GHI {{ my_var }}
+      - Name: "myslot"
+         ID 0003
+         Content:
+         | ------- JKL {{ my_var }}
+         | ------- {% slot "myslot_inner" %}
+         | ---------- MNO {{ my_var }}
+         | ------- {% endslot %}
+      - Name: "myslot_inner"
+         ID 0004
+         Content:
+         | ---------- MNO {{ my_var }}
+      - Name: "myslot2"
+         ID 0005
+         Content:
+         | ---- PQR {{ my_var }}
+      ```
+
+   2. Note the relationships - which slot is nested in which one
+    
+      I should end up with a graph-like data like:
+      ```txt
+      - 0001: [0002]
+      - 0002: []
+      - 0003: [0004]
+      - 0004: []
+      - 0005: []
+      ```
+
+      In other words, the data tells us that slot ID `0001` is PARENT of slot `0002`.
+
+      This is important, because, IF parent template provides slot fill for slot 0001,
+      then we DON'T NEED TO render it's children, AKA slot 0002.
+
+   3. Find roots of the slot relationships
+
+      The data from previous step can be understood also as a collection of
+      directled acyclig graphs (DAG), e.g.:
+
+      ```txt
+      0001 --> 0002
+      0003 --> 0004
+      0005
+      ```
+
+      So we find the roots (`0001`, `0003`, `0005`), AKA slots that are NOT nested in other slots.
+      We do so by going over ALL entries from previous step. Those IDs which are NOT
+      mentioned in ANY of the lists are the roots.
+
+      Because of the nature of nested structures, there cannot be any cycles.
+
+   4. Recursively render slots, starting from roots.      
+      1. First we take each of the roots.
+
+      2. Then we check if there is a slot fill for given slot name.
+
+      3. If YES we replace the slot node with the fill node.
+         - Note: We assume slot fills are ALREADY RENDERED!
+         ```django
+         | ----- {% slot "myslot_inner" %}
+         | -------- GHI {{ my_var }}
+         | ----- {% endslot %}
+         ```
+         becomes
+         ```django
+         | ----- Bla bla
+         | -------- Some Other Content
+         | ----- ...
+         ```
+         We don't continue further, because inner slots have been overriden!
+
+      4. If NO, then we will replace slot nodes with their children, e.g.:
+         ```django
+         | ---- {% slot "myslot" %} ---
+         | ------- JKL {{ my_var }}
+         | ------- {% slot "myslot_inner" %}
+         | ---------- MNO {{ my_var }}
+         | ------- {% endslot %}
+         | ---- {% endslot %} ---
+         ```
+         Becomes
+         ```django
+         | ------- JKL {{ my_var }}
+         | ------- {% slot "myslot_inner" %}
+         | ---------- MNO {{ my_var }}
+         | ------- {% endslot %}
+         ```
+
+      5. We check if the slot includes any children `{% slot %}` tags. If YES, then continue with step 4. for them, and wait until they finish.
+
+   5. At this point, ALL slots should be rendered and we should have something like this:
+      ```django
+      | -- {{ my_var }} --
+      | -- ABC
+      | ----- DEF {{ my_var }}
+      | -------- GHI {{ my_var }}
+      | ------
+      | -- {% component "mycomp" %} ---
+      | ------- JKL {{ my_var }}
+      | ---- {% component "mycomp" %} ---
+      | ---------- MNO {{ my_var }}
+      | ---- {% endcomponent %} ---
+      | -- {% endcomponent %} ---
+      | ----
+      | -- {% component "mycomp2" %} ---
+      | ---- PQR {{ my_var }}
+      | -- {% endcomponent %} ---
+      | ----
+      ```
+      - NOTE: Inserting fills into {% slots %} should NOT introduce new {% slots %}, as the fills should be already rendered!
+
+## Using the correct context in {% slot/fill %} tags
+
+In previous section, we said that the `{% fill %}` tags should be already rendered by the time they are inserted into the `{% slot %}` tags.
+
+This is not quite true. To help you understand, consider this complex case:
+
+```django
+| -- {% for var in [1, 2, 3] %} ---
+| ---- {% component "mycomp2" %} ---
+| ------ {% fill "first" %}
+| ------- STU {{ my_var }}
+| -------     {{ var }}
+| ------ {% endfill %}
+| ------ {% fill "second" %}
+| -------- {% component var=var my_var=my_var %}
+| ---------- VWX {{ my_var }}
+| -------- {% endcomponent %}
+| ------ {% endfill %}
+| ---- {% endcomponent %} ---
+| -- {% endfor %} ---
+| -------
+```
+
+We want the forloop variables to be available inside the `{% fill %}` tags. Because of that, however, we CANNOT render the fills/slots in advance.
+
+Instead, our solution is closer to [how Vue handles slots](https://vuejs.org/guide/components/slots.html#scoped-slots). In Vue, slots are effectively functions that accept a context variables and render some content.
+
+While we do not wrap the logic in a function, we do PREPARE IN ADVANCE:
+1. The content that should be rendered for each slot
+2. The context variables from `get_context_data()`
+
+Thus, once we reach the `{% slot %}` node, in it's `render()` method, we access the data above, and, depending on the `context_behavior` setting, include the current context or not. For more info, see `SlotNode.render()`.

--- a/sampleproject/sampleproject/settings.py
+++ b/sampleproject/sampleproject/settings.py
@@ -84,8 +84,7 @@ WSGI_APPLICATION = "sampleproject.wsgi.application"
 #    "autodiscover": True,
 #    "libraries": [],
 #    "template_cache_size": 128,
-#    "context_behavior": "isolated",  # "global" | "isolated"
-#    "slot_context_behavior": "prefer_root",  # "allow_override" | "prefer_root" | "isolated"
+#    "context_behavior": "isolated",  # "django" | "isolated"
 # }
 
 

--- a/src/django_components/app_settings.py
+++ b/src/django_components/app_settings.py
@@ -5,27 +5,27 @@ from django.conf import settings
 
 
 class ContextBehavior(str, Enum):
-    GLOBAL = "global"
-    ISOLATED = "isolated"
-
-
-class SlotContextBehavior(str, Enum):
-    ALLOW_OVERRIDE = "allow_override"
+    DJANGO = "django"
     """
-    Components CAN override the slot context variables passed from the outer scopes.
-    Contexts of deeper components take precedence over shallower ones.
+    With this setting, component fills behave as usual Django tags.
+    That is, they enrich the context, and pass it along.
+
+    1. Component fills use the context of the component they are within.
+    2. Variables from `get_context_data` are available to the component fill.
 
     Example:
 
     Given this template
-
-    ```txt
-    {% component 'my_comp' %}
-      {{ my_var }}
-    {% endcomponent %}
+    ```django
+    {% with cheese="feta" %}
+      {% component 'my_comp' %}
+        {{ my_var }}  # my_var
+        {{ cheese }}  # cheese
+      {% endcomponent %}
+    {% endwith %}
     ```
 
-    and this context passed to the render function (AKA root context)
+    and this context returned from the `get_context_data()` method
     ```py
     { "my_var": 123 }
     ```
@@ -35,59 +35,37 @@ class SlotContextBehavior(str, Enum):
     { "my_var": 456 }
     ```
 
-    Then since "my_comp" overrides the varialbe "my_var", so `{{ my_var }}` will equal `456`.
-    """
-
-    PREFER_ROOT = "prefer_root"
-    """
-    This is the same as "allow_override", except any variables defined in the root context
-    take precedence over anything else.
-
-    So if a variable is found in the root context, then root context is used.
-    Otherwise, the context of the component where the slot fill is located is used.
-
-    Example:
-
-    Given this template
-
-    ```txt
-    {% component 'my_comp' %}
-      {{ my_var_one }}
-      {{ my_var_two }}
-    {% endcomponent %}
+    Then this will render:
+    ```django
+    456   # my_var
+    feta  # cheese
     ```
 
-    and this context passed to the render function (AKA root context)
-    ```py
-    { "my_var_one": 123 }
-    ```
+    Because "my_comp" overrides the variable "my_var",
+    so `{{ my_var }}` equals `456`.
 
-    Then if component "my_comp" defines context
-    ```py
-    { "my_var": 456, "my_var_two": "abc" }
-    ```
-
-    Then the rendered `{{ my_var_one }}` will equal to `123`, and `{{ my_var_two }}`
-    will equal to "abc".
+    And variable "cheese" will equal `feta`, because the fill CAN access
+    the current context.
     """
 
     ISOLATED = "isolated"
     """
-    This setting makes the slots behave similar to Vue or React, where
-    the slot uses EXCLUSIVELY the root context, and nested components CANNOT
-    override context variables inside the slots.
+    This setting makes the component fills behave similar to Vue or React, where
+    the fills use EXCLUSIVELY the context variables defined in `get_context_data`.
 
     Example:
 
     Given this template
-
-    ```txt
-    {% component 'my_comp' %}
-      {{ my_var }}
-    {% endcomponent %}
+    ```django
+    {% with cheese="feta" %}
+      {% component 'my_comp' %}
+        {{ my_var }}  # my_var
+        {{ cheese }}  # cheese
+      {% endcomponent %}
+    {% endwith %}
     ```
 
-    and this context passed to the render function (AKA root context)
+    and this context returned from the `get_context_data()` method
     ```py
     { "my_var": 123 }
     ```
@@ -97,7 +75,14 @@ class SlotContextBehavior(str, Enum):
     { "my_var": 456 }
     ```
 
-    Then the rendered `{{ my_var }}` will equal `123`.
+    Then this will render:
+    ```django
+    123   # my_var
+          # cheese
+    ```
+
+    Because both variables "my_var" and "cheese" are taken from the root context.
+    Since "cheese" is not defined in root context, it's empty.
     """
 
 
@@ -120,7 +105,7 @@ class AppSettings:
 
     @property
     def CONTEXT_BEHAVIOR(self) -> ContextBehavior:
-        raw_value = self.settings.get("context_behavior", ContextBehavior.GLOBAL.value)
+        raw_value = self.settings.get("context_behavior", ContextBehavior.ISOLATED.value)
         return self._validate_context_behavior(raw_value)
 
     def _validate_context_behavior(self, raw_value: ContextBehavior) -> ContextBehavior:
@@ -129,18 +114,6 @@ class AppSettings:
         except ValueError:
             valid_values = [behavior.value for behavior in ContextBehavior]
             raise ValueError(f"Invalid context behavior: {raw_value}. Valid options are {valid_values}")
-
-    @property
-    def SLOT_CONTEXT_BEHAVIOR(self) -> SlotContextBehavior:
-        raw_value = self.settings.get("slot_context_behavior", SlotContextBehavior.PREFER_ROOT.value)
-        return self._validate_slot_context_behavior(raw_value)
-
-    def _validate_slot_context_behavior(self, raw_value: SlotContextBehavior) -> SlotContextBehavior:
-        try:
-            return SlotContextBehavior(raw_value)
-        except ValueError:
-            valid_values = [behavior.value for behavior in SlotContextBehavior]
-            raise ValueError(f"Invalid slot context behavior: {raw_value}. Valid options are {valid_values}")
 
 
 app_settings = AppSettings()

--- a/src/django_components/context.py
+++ b/src/django_components/context.py
@@ -8,6 +8,7 @@ You can think of the Context as our storage system.
 from typing import TYPE_CHECKING, Optional
 
 from django.template import Context
+from django.template.exceptions import TemplateSyntaxError
 
 from django_components.app_settings import SlotContextBehavior, app_settings
 from django_components.logger import trace_msg
@@ -107,6 +108,10 @@ def set_slot_fill(context: Context, component_id: str, slot_name: str, value: "F
     extra contexts on top others.
     """
     trace_msg("SET", "FILL", slot_name, component_id)
+
+    if not slot_name.isidentifier():
+        raise TemplateSyntaxError(f"Slot names must be valid Python identifiers, instead got '{slot_name}'")
+
     slot_key = f"{component_id}__{slot_name}"
     context[_FILLED_SLOTS_CONTENT_CONTEXT_KEY][slot_key] = value
 

--- a/src/django_components/context.py
+++ b/src/django_components/context.py
@@ -22,6 +22,7 @@ _OUTER_ROOT_CTX_CONTEXT_KEY = "_DJANGO_COMPONENTS_OUTER_ROOT_CTX"
 _SLOT_COMPONENT_ASSOC_KEY = "_DJANGO_COMPONENTS_SLOT_COMP_ASSOC"
 _PARENT_COMP_KEY = "_DJANGO_COMPONENTS_PARENT_COMP"
 _CURRENT_COMP_KEY = "_DJANGO_COMPONENTS_CURRENT_COMP"
+_FILLED_SLOTS_BOOL_CONTEXT_KEY = "slots"
 
 
 def prepare_context(
@@ -108,6 +109,12 @@ def set_slot_fill(context: Context, component_id: str, slot_name: str, value: "F
     trace_msg("SET", "FILL", slot_name, component_id)
     slot_key = f"{component_id}__{slot_name}"
     context[_FILLED_SLOTS_CONTENT_CONTEXT_KEY][slot_key] = value
+
+    # Set variable that users may check to see if given slot was filled
+    # E.g. `{% if variable > 8 and slots.header %}`
+    if _FILLED_SLOTS_BOOL_CONTEXT_KEY not in context.dicts[-1]:
+        context.dicts[-1][_FILLED_SLOTS_BOOL_CONTEXT_KEY] = {}
+    context.dicts[-1][_FILLED_SLOTS_BOOL_CONTEXT_KEY][slot_name] = value is not None
 
 
 def get_outer_root_context(context: Context) -> Optional[Context]:

--- a/src/django_components/context.py
+++ b/src/django_components/context.py
@@ -5,75 +5,38 @@ pass data across components, nodes, slots, and contexts.
 You can think of the Context as our storage system.
 """
 
-from typing import TYPE_CHECKING, Optional
-
 from django.template import Context
-from django.template.exceptions import TemplateSyntaxError
 
-from django_components.app_settings import SlotContextBehavior, app_settings
-from django_components.logger import trace_msg
 from django_components.utils import find_last_index
-
-if TYPE_CHECKING:
-    from django_components.slots import FillContent
 
 
 _FILLED_SLOTS_CONTENT_CONTEXT_KEY = "_DJANGO_COMPONENTS_FILLED_SLOTS"
-_OUTER_ROOT_CTX_CONTEXT_KEY = "_DJANGO_COMPONENTS_OUTER_ROOT_CTX"
-_SLOT_COMPONENT_ASSOC_KEY = "_DJANGO_COMPONENTS_SLOT_COMP_ASSOC"
-_PARENT_COMP_KEY = "_DJANGO_COMPONENTS_PARENT_COMP"
-_CURRENT_COMP_KEY = "_DJANGO_COMPONENTS_CURRENT_COMP"
-_FILLED_SLOTS_BOOL_CONTEXT_KEY = "slots"
+_ROOT_CTX_CONTEXT_KEY = "_DJANGO_COMPONENTS_ROOT_CTX"
+_PARENT_COMP_CONTEXT_KEY = "_DJANGO_COMPONENTS_PARENT_COMP"
+_CURRENT_COMP_CONTEXT_KEY = "_DJANGO_COMPONENTS_CURRENT_COMP"
 
 
 def prepare_context(
     context: Context,
-    outer_context: Optional[Context],
     component_id: str,
 ) -> None:
     """Initialize the internal context state."""
-    # This is supposed to run ALWAYS at `Component.render()`
-    if outer_context is not None:
-        set_outer_root_context(context, outer_context)
-
     # Initialize mapping dicts within this rendering run.
     # This is shared across the whole render chain, thus we set it only once.
-    if _SLOT_COMPONENT_ASSOC_KEY not in context:
-        context[_SLOT_COMPONENT_ASSOC_KEY] = {}
     if _FILLED_SLOTS_CONTENT_CONTEXT_KEY not in context:
         context[_FILLED_SLOTS_CONTENT_CONTEXT_KEY] = {}
-
-    # If we're inside a forloop, we need to make a disposable copy of slot -> comp
-    # mapping, which can be modified in the loop. We do so by copying it onto the latest
-    # context layer.
-    #
-    # This is necessary, because otherwise if we have a nested loop with a same
-    # component used recursively, the inner slot -> comp mapping would leak into the outer.
-    #
-    # NOTE: If you ever need to debug this, insert a print/debug statement into
-    # `django.template.defaulttags.ForNode.render` to inspect the context object
-    # inside the for loop.
-    if "forloop" in context:
-        context.dicts[-1][_SLOT_COMPONENT_ASSOC_KEY] = context[_SLOT_COMPONENT_ASSOC_KEY].copy()
 
     set_component_id(context, component_id)
 
 
 def make_isolated_context_copy(context: Context) -> Context:
-    # Even if contexts are isolated, we still need to pass down the
-    # metadata so variables in slots can be rendered using the correct context.
-    root_ctx = get_outer_root_context(context)
-    slot_assoc = context.get(_SLOT_COMPONENT_ASSOC_KEY, {})
-    slot_fills = context.get(_FILLED_SLOTS_CONTENT_CONTEXT_KEY, {})
-
     context_copy = context.new()
-    context_copy[_SLOT_COMPONENT_ASSOC_KEY] = slot_assoc
-    context_copy[_FILLED_SLOTS_CONTENT_CONTEXT_KEY] = slot_fills
-    set_outer_root_context(context_copy, root_ctx)
     copy_forloop_context(context, context_copy)
 
-    context_copy[_CURRENT_COMP_KEY] = context.get(_CURRENT_COMP_KEY, None)
-    context_copy[_PARENT_COMP_KEY] = context.get(_PARENT_COMP_KEY, None)
+    # Pass through our internal keys
+    context_copy[_FILLED_SLOTS_CONTENT_CONTEXT_KEY] = context.get(_FILLED_SLOTS_CONTENT_CONTEXT_KEY, {})
+    if _ROOT_CTX_CONTEXT_KEY in context:
+        context_copy[_ROOT_CTX_CONTEXT_KEY] = context.get(_ROOT_CTX_CONTEXT_KEY, {})
 
     return context_copy
 
@@ -85,146 +48,8 @@ def set_component_id(context: Context, component_id: str) -> None:
     """
     # Store the previous component so we can detect if the current component
     # is the top-most or not. If it is, then "_parent_component_id" is None
-    context[_PARENT_COMP_KEY] = context.get(_CURRENT_COMP_KEY, None)
-    context[_CURRENT_COMP_KEY] = component_id
-
-
-def get_slot_fill(context: Context, component_id: str, slot_name: str) -> Optional["FillContent"]:
-    """
-    Use this function to obtain a slot fill from the current context.
-
-    See `set_slot_fill` for more details.
-    """
-    trace_msg("GET", "FILL", slot_name, component_id)
-    slot_key = f"{component_id}__{slot_name}"
-    return context[_FILLED_SLOTS_CONTENT_CONTEXT_KEY].get(slot_key, None)
-
-
-def set_slot_fill(context: Context, component_id: str, slot_name: str, value: "FillContent") -> None:
-    """
-    Use this function to set a slot fill for the current context.
-
-    Note that we make use of the fact that Django's Context is a stack - we can push and pop
-    extra contexts on top others.
-    """
-    trace_msg("SET", "FILL", slot_name, component_id)
-
-    if not slot_name.isidentifier():
-        raise TemplateSyntaxError(f"Slot names must be valid Python identifiers, instead got '{slot_name}'")
-
-    slot_key = f"{component_id}__{slot_name}"
-    context[_FILLED_SLOTS_CONTENT_CONTEXT_KEY][slot_key] = value
-
-    # Set variable that users may check to see if given slot was filled
-    # E.g. `{% if variable > 8 and slots.header %}`
-    if _FILLED_SLOTS_BOOL_CONTEXT_KEY not in context.dicts[-1]:
-        context.dicts[-1][_FILLED_SLOTS_BOOL_CONTEXT_KEY] = {}
-    context.dicts[-1][_FILLED_SLOTS_BOOL_CONTEXT_KEY][slot_name] = value is not None
-
-
-def get_outer_root_context(context: Context) -> Optional[Context]:
-    """
-    Use this function to get the outer root context.
-
-    See `set_outer_root_context` for more details.
-    """
-    return context.get(_OUTER_ROOT_CTX_CONTEXT_KEY)
-
-
-def set_outer_root_context(context: Context, outer_ctx: Optional[Context]) -> None:
-    """
-    Use this function to set the outer root context.
-
-    When we consider a component's template, then outer context is the context
-    that was available just outside of the component's template (AKA it was in
-    the PARENT template).
-
-    Once we have the outer context, next we get the outer ROOT context. This is
-    the context that was available at the top level of the PARENT template.
-
-    We pass through this context to allow to configure how slot fills should be
-    rendered using the `SLOT_CONTEXT_BEHAVIOR` setting.
-    """
-    # Special case for handling outer context of top-level components when
-    # slots are isolated. In such case, the entire outer context is to be the
-    # outer root ctx.
-    if (
-        outer_ctx
-        and not context.get(_PARENT_COMP_KEY)
-        and app_settings.SLOT_CONTEXT_BEHAVIOR == SlotContextBehavior.ISOLATED
-        and _OUTER_ROOT_CTX_CONTEXT_KEY in context  # <-- Added to avoid breaking tests
-    ):
-        outer_root_context = outer_ctx.new()
-        outer_root_context.push(outer_ctx.flatten())
-
-    # In nested components, the context generated from `get_context_data`
-    # is found at index 1.
-    # NOTE:
-    # - Index 0 are the defaults set in BaseContext
-    # - Index 1 is the context generated by `Component.get_context_data`
-    #   of the parent's component
-    # - All later indices (2, 3, ...) are extra layers added by the rendering
-    #   logic (each Node usually adds it's own context layer)
-    elif outer_ctx and len(outer_ctx.dicts) > 1:
-        outer_root_context = outer_ctx.new()
-        outer_root_context.push(outer_ctx.dicts[1])
-
-    # Fallback
-    else:
-        outer_root_context = Context()
-
-    # Include the mappings.
-    if _SLOT_COMPONENT_ASSOC_KEY in context:
-        outer_root_context[_SLOT_COMPONENT_ASSOC_KEY] = context[_SLOT_COMPONENT_ASSOC_KEY]
-    if _FILLED_SLOTS_CONTENT_CONTEXT_KEY in context:
-        outer_root_context[_FILLED_SLOTS_CONTENT_CONTEXT_KEY] = context[_FILLED_SLOTS_CONTENT_CONTEXT_KEY]
-
-    context[_OUTER_ROOT_CTX_CONTEXT_KEY] = outer_root_context
-
-
-def set_slot_component_association(
-    context: Context,
-    slot_id: str,
-    component_id: str,
-) -> None:
-    """
-    Set association between a Slot and a Component in the current context.
-
-    We use SlotNodes to render slot fills. SlotNodes are created only at Template
-    parse time.
-    However, when we refer to components with slots in (another) template (using
-    `{% component %}`), we can render the same component multiple time. So we can
-    have multiple FillNodes intended to be used with the same SlotNode.
-
-    So how do we tell the SlotNode which FillNode to render? We do so by tagging
-    the ComponentNode and FillNodes with a unique component_id, which ties them
-    together. And then we tell SlotNode which component_id to use to be able to
-    find the correct Component/Fill.
-
-    We don't want to store this info on the Nodes themselves, as we need to treat
-    them as immutable due to caching of Templates by Django.
-
-    Hence, we use the Context to store the associations of SlotNode <-> Component
-    for the current context stack.
-    """
-    # Store associations on the latest context layer so that we can nest components
-    # onto themselves (component A is rendered in slot fill of component A).
-    # Otherwise, they would overwrite each other as the ComponentNode and SlotNodes
-    # are re-used, so their IDs don't change across these two occurences.
-    latest_dict = context.dicts[-1]
-    if _SLOT_COMPONENT_ASSOC_KEY not in latest_dict:
-        latest_dict[_SLOT_COMPONENT_ASSOC_KEY] = context[_SLOT_COMPONENT_ASSOC_KEY].copy()
-    context[_SLOT_COMPONENT_ASSOC_KEY][slot_id] = component_id
-
-
-def get_slot_component_association(context: Context, slot_id: str) -> str:
-    """
-    Given a slot ID, get the component ID that this slot is associated with
-    in this context.
-
-    See `set_slot_component_association` for more details.
-    """
-    return context[_SLOT_COMPONENT_ASSOC_KEY][slot_id]
+    context[_PARENT_COMP_CONTEXT_KEY] = context.get(_CURRENT_COMP_CONTEXT_KEY, None)
+    context[_CURRENT_COMP_CONTEXT_KEY] = component_id
 
 
 def copy_forloop_context(from_context: Context, to_context: Context) -> None:

--- a/src/django_components/logger.py
+++ b/src/django_components/logger.py
@@ -80,7 +80,7 @@ def trace_msg(
         if not component_id:
             raise ValueError("component_id must be set for the ASSOC action")
         msg_prefix = f"TO COMP {component_id}"
-    elif action == "RENDR" and node_type != "COMP":
+    elif action == "RENDR" and node_type == "FILL":
         if not component_id:
             raise ValueError("component_id must be set for the RENDER action")
         msg_prefix = f"FOR COMP {component_id}"

--- a/src/django_components/logger.py
+++ b/src/django_components/logger.py
@@ -63,7 +63,7 @@ def trace(logger: logging.Logger, message: str, *args: Any, **kwargs: Any) -> No
 
 def trace_msg(
     action: Literal["PARSE", "ASSOC", "RENDR", "GET", "SET"],
-    node_type: Literal["COMP", "FILL", "SLOT", "IFSB", "N/A"],
+    node_type: Literal["COMP", "FILL", "SLOT", "N/A"],
     node_name: str,
     node_id: str,
     msg: str = "",

--- a/src/django_components/node.py
+++ b/src/django_components/node.py
@@ -1,4 +1,4 @@
-from typing import Callable
+from typing import Callable, List, NamedTuple, Optional
 
 from django.template.base import Node, NodeList, TextNode
 from django.template.defaulttags import CommentNode
@@ -15,13 +15,20 @@ def nodelist_has_content(nodelist: NodeList) -> bool:
     return False
 
 
-def walk_nodelist(nodes: NodeList, callback: Callable[[Node], None]) -> None:
+class NodeTraverse(NamedTuple):
+    node: Node
+    parent: Optional["NodeTraverse"]
+
+
+def walk_nodelist(nodes: NodeList, callback: Callable[[Node], Optional[str]]) -> None:
     """Recursively walk a NodeList, calling `callback` for each Node."""
-    node_queue = [*nodes]
+    node_queue: List[NodeTraverse] = [NodeTraverse(node=node, parent=None) for node in nodes]
     while len(node_queue):
-        node: Node = node_queue.pop()
-        callback(node)
-        node_queue.extend(get_node_children(node))
+        traverse = node_queue.pop()
+        callback(traverse)
+        child_nodes = get_node_children(traverse.node)
+        child_traverses = [NodeTraverse(node=child_node, parent=traverse) for child_node in child_nodes]
+        node_queue.extend(child_traverses)
 
 
 def get_node_children(node: Node) -> NodeList:

--- a/src/django_components/slots.py
+++ b/src/django_components/slots.py
@@ -417,13 +417,14 @@ def _collect_slot_fills_from_component_template(
             continue
 
         slot_name = node.name
+
+        # If true then the template contains multiple slot of the same name.
+        # No action needed, since even tho there's mutliple slots, we will
+        # still apply only a single fill to all of them. And each slot handles
+        # their own fallback content.
         if slot_name in slot_name2fill_content:
-            raise TemplateSyntaxError(
-                f"Slot name '{slot_name}' re-used within the same template. "
-                f"Slot names must be unique."
-                f"To fix, check template '{template.name}' "
-                f"of component '{registered_name}'."
-            )
+            continue
+
         if node.is_required:
             required_slot_names.add(node.name)
 

--- a/src/django_components/templatetags/component_tags.py
+++ b/src/django_components/templatetags/component_tags.py
@@ -6,7 +6,7 @@ from django.template.exceptions import TemplateSyntaxError
 from django.template.library import parse_bits
 from django.utils.safestring import SafeString, mark_safe
 
-from django_components.app_settings import app_settings
+from django_components.app_settings import app_settings, ContextBehavior
 from django_components.component import RENDERED_COMMENT_TEMPLATE, ComponentNode
 from django_components.component_registry import ComponentRegistry
 from django_components.component_registry import registry as component_registry
@@ -266,7 +266,7 @@ def check_for_isolated_context_keyword(bits: List[str]) -> Tuple[List[str], bool
     if bits[-1] == "only":
         return bits[:-1], True
 
-    if app_settings.CONTEXT_BEHAVIOR == "isolated":
+    if app_settings.CONTEXT_BEHAVIOR == ContextBehavior.ISOLATED:
         return bits, True
 
     return bits, False

--- a/tests/templates/template_is_filled.html
+++ b/tests/templates/template_is_filled.html
@@ -1,0 +1,10 @@
+{% load component_tags %}
+<div class="frontmatter-component">
+    {% slot "title" %}{% endslot %}
+    {% slot "my_title" %}{% endslot %}
+    {% slot "my title 1" %}{% endslot %}
+    {% slot "my-title-2" %}{% endslot %}
+    {% slot "escape this: #$%^*()" %}{% endslot %}
+
+    {{ component_vars.is_filled }}
+</div>

--- a/tests/templates/template_with_conditional_slots.html
+++ b/tests/templates/template_with_conditional_slots.html
@@ -2,7 +2,7 @@
 {% load component_tags %}
 <div class="frontmatter-component">
     <div class="title">{% slot "title" %}Title{% endslot %}</div>
-    {% if slots.subtitle %}
+    {% if component_vars.is_filled.subtitle %}
         <div class="subtitle">{% slot "subtitle" %}Optional subtitle{% endslot %}</div>
     {% endif %}
 </div>

--- a/tests/templates/template_with_conditional_slots.html
+++ b/tests/templates/template_with_conditional_slots.html
@@ -2,7 +2,7 @@
 {% load component_tags %}
 <div class="frontmatter-component">
     <div class="title">{% slot "title" %}Title{% endslot %}</div>
-    {% if_filled "subtitle" %}
+    {% if slots.subtitle %}
         <div class="subtitle">{% slot "subtitle" %}Optional subtitle{% endslot %}</div>
-    {% endif_filled %}
+    {% endif %}
 </div>

--- a/tests/templates/template_with_if_elif_else_conditional_slots.html
+++ b/tests/templates/template_with_if_elif_else_conditional_slots.html
@@ -2,11 +2,11 @@
 {% load component_tags %}
 <div class="frontmatter-component">
     <div class="title">{% slot "title" %}Title{% endslot %}</div>
-    {% if_filled 'subtitle'%}
+    {% if slots.subtitle %}
         <div class="subtitle">{% slot "subtitle" %}Optional subtitle{% endslot %}</div>
-    {% elif_filled "alt_subtitle" %}
+    {% elif slots.alt_subtitle %}
         <div class="subtitle">{% slot "alt_subtitle" %}Why would you want this?{% endslot %}</div>
-    {% else_filled %}
+    {% else %}
        <div class="warning">Nothing filled!</div>
-    {% endif_filled %}
+    {% endif %}
 </div>

--- a/tests/templates/template_with_negated_conditional_slots.html
+++ b/tests/templates/template_with_negated_conditional_slots.html
@@ -2,9 +2,9 @@
 {% load component_tags %}
 <div class="frontmatter-component">
     <div class="title">{% slot "title" %}Title{% endslot %}</div>
-    {% if_filled "subtitle" False %}
+    {% if not slots.subtitle %}
        <div class="warning">Subtitle not filled!</div>
-    {% else_filled %}
+    {% else %}
         <div class="subtitle">{% slot "alt_subtitle" %}Why would you want this?{% endslot %}</div>
-    {% endif_filled %}
+    {% endif %}
 </div>

--- a/tests/templates/template_with_negated_conditional_slots.html
+++ b/tests/templates/template_with_negated_conditional_slots.html
@@ -2,7 +2,7 @@
 {% load component_tags %}
 <div class="frontmatter-component">
     <div class="title">{% slot "title" %}Title{% endslot %}</div>
-    {% if not slots.subtitle %}
+    {% if not component_vars.is_filled.subtitle %}
        <div class="warning">Subtitle not filled!</div>
     {% else %}
         <div class="subtitle">{% slot "alt_subtitle" %}Why would you want this?{% endslot %}</div>

--- a/tests/templates/template_with_nonunique_slots_nested.html
+++ b/tests/templates/template_with_nonunique_slots_nested.html
@@ -1,0 +1,16 @@
+{% load component_tags %}
+{% slot "header" %}START{% endslot %}
+<div class="dashboard-component">
+  {% component "calendar" date="2020-06-06" %}
+    {% fill "header" %}  {# fills and slots with same name relate to diff. things. #}
+      {% slot "header" %}NESTED{% endslot %}
+    {% endfill %}
+    {% fill "body" %}Here are your to-do items for today:{% endfill %}
+  {% endcomponent %}
+  <ol>
+    {% for item in items %}
+      <li>{{ item }}</li>
+      {% slot "header" %}LOOP {{ item }} {% endslot %}
+    {% endfor %}
+  </ol>
+</div>

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -54,7 +54,8 @@ class DuplicateSlotNestedComponent(component.Component):
         return {
             "items": items,
         }
-    
+
+
 class CalendarComponent(component.Component):
     """Nested in ComponentWithNestedComponent"""
 
@@ -64,6 +65,7 @@ class CalendarComponent(component.Component):
 #########################
 # TESTS
 #########################
+
 
 class ComponentTest(BaseTestCase):
     @classmethod
@@ -450,7 +452,7 @@ class DuplicateSlotTest(BaseTestCase):
             """
         )
         rendered = self.template.render(Context({}))
-    
+
         # NOTE: Slots should have different fallbacks even though they use the same name
         self.assertHTMLEqual(
             rendered,
@@ -473,7 +475,7 @@ class DuplicateSlotTest(BaseTestCase):
             """
         )
         rendered = self.template.render(Context({"items": [1, 2, 3]}))
-    
+
         # NOTE: Slots should have different fallbacks even though they use the same name
         self.assertHTMLEqual(
             rendered,
@@ -510,7 +512,7 @@ class DuplicateSlotTest(BaseTestCase):
             """
         )
         rendered = self.template.render(Context({"items": [1, 2, 3]}))
-    
+
         # NOTE: Slots should have different fallbacks even though they use the same name
         self.assertHTMLEqual(
             rendered,

--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -1,6 +1,6 @@
 import sys
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from django.core.exceptions import ImproperlyConfigured
 from django.template import Context, Template
@@ -38,10 +38,32 @@ class VariableDisplay(component.Component):
         return context
 
 
+class DuplicateSlotComponent(component.Component):
+    template_name = "template_with_nonunique_slots.html"
+
+    def get_context_data(self, name: Optional[str] = None) -> Dict[str, Any]:
+        return {
+            "name": name,
+        }
+
+
+class DuplicateSlotNestedComponent(component.Component):
+    template_name = "template_with_nonunique_slots_nested.html"
+
+    def get_context_data(self, items: List) -> Dict[str, Any]:
+        return {
+            "items": items,
+        }
+    
+class CalendarComponent(component.Component):
+    """Nested in ComponentWithNestedComponent"""
+
+    template_name = "slotted_component_nesting_template_pt1_calendar.html"
+
+
 #########################
 # TESTS
 #########################
-
 
 class ComponentTest(BaseTestCase):
     @classmethod
@@ -382,6 +404,137 @@ class ComponentTest(BaseTestCase):
                     <main> ABC: carl </main>
                 </div>
             </body>
+            """,
+        )
+
+
+class DuplicateSlotTest(BaseTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        component.registry.register(name="duplicate_slot", component=DuplicateSlotComponent)
+        component.registry.register(name="duplicate_slot_nested", component=DuplicateSlotNestedComponent)
+        component.registry.register(name="calendar", component=CalendarComponent)
+
+    def test_duplicate_slots(self):
+        self.template = Template(
+            """
+            {% load component_tags %}
+            {% component "duplicate_slot" %}
+                {% fill "header" %}
+                    Name: {{ name }}
+                {% endfill %}
+                {% fill "footer" %}
+                    Hello
+                {% endfill %}
+            {% endcomponent %}
+            """
+        )
+
+        rendered = self.template.render(Context({"name": "Jannete"}))
+        self.assertHTMLEqual(
+            rendered,
+            """
+            <header>Name: Jannete</header>
+            <main>Name: Jannete</main>
+            <footer>Hello</footer>
+            """,
+        )
+
+    def test_duplicate_slots_fallback(self):
+        self.template = Template(
+            """
+            {% load component_tags %}
+            {% component "duplicate_slot" %}
+            {% endcomponent %}
+            """
+        )
+        rendered = self.template.render(Context({}))
+    
+        # NOTE: Slots should have different fallbacks even though they use the same name
+        self.assertHTMLEqual(
+            rendered,
+            """
+            <header>Default header</header>
+            <main>Default main header</main>
+            <footer>Default footer</footer>
+            """,
+        )
+
+    def test_duplicate_slots_nested(self):
+        self.template = Template(
+            """
+            {% load component_tags %}
+            {% component "duplicate_slot_nested" items=items %}
+                {% fill "header" %}
+                    OVERRIDDEN!
+                {% endfill %}
+            {% endcomponent %}
+            """
+        )
+        rendered = self.template.render(Context({"items": [1, 2, 3]}))
+    
+        # NOTE: Slots should have different fallbacks even though they use the same name
+        self.assertHTMLEqual(
+            rendered,
+            """
+            OVERRIDDEN!
+            <div class="dashboard-component">
+                <div class="calendar-component">
+                    <h1>
+                        OVERRIDDEN!
+                    </h1>
+                    <main>
+                        Here are your to-do items for today:
+                    </main>
+                </div>
+
+                <ol>
+                    <li>1</li>
+                    OVERRIDDEN!
+                    <li>2</li>
+                    OVERRIDDEN!
+                    <li>3</li>
+                    OVERRIDDEN!
+                </ol>
+            </div>
+            """,
+        )
+
+    def test_duplicate_slots_nested_fallback(self):
+        self.template = Template(
+            """
+            {% load component_tags %}
+            {% component "duplicate_slot_nested" items=items %}
+            {% endcomponent %}
+            """
+        )
+        rendered = self.template.render(Context({"items": [1, 2, 3]}))
+    
+        # NOTE: Slots should have different fallbacks even though they use the same name
+        self.assertHTMLEqual(
+            rendered,
+            """
+            START
+            <div class="dashboard-component">
+                <div class="calendar-component">
+                    <h1>
+                        NESTED
+                    </h1>
+                    <main>
+                        Here are your to-do items for today:
+                    </main>
+                </div>
+
+                <ol>
+                    <li>1</li>
+                    LOOP 1
+                    <li>2</li>
+                    LOOP 2
+                    <li>3</li>
+                    LOOP 3
+                </ol>
+            </div>
             """,
         )
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -213,17 +213,63 @@ class ParentArgsTests(BaseTestCase):
         component.registry.register(name="parent_with_args", component=ParentComponentWithArgs)
         component.registry.register(name="variable_display", component=VariableDisplay)
 
-    def test_parent_args_can_be_drawn_from_context(self):
-        template = Template(
-            "{% load component_tags %}{% component_dependencies %}"
-            "{% component 'parent_with_args' parent_value=parent_value %}"
-            "{% endcomponent %}"
-        )
+    @override_settings(
+        COMPONENTS={
+            "context_behavior": "django",
+        }
+    )
+    def test_parent_args_can_be_drawn_from_context__django(self):
+        template = Template("""
+            {% load component_tags %}{% component_dependencies %}
+            {% component 'parent_with_args' parent_value=parent_value %}
+            {% endcomponent %}
+        """)
         rendered = template.render(Context({"parent_value": "passed_in"}))
 
-        self.assertIn("<h1>Shadowing variable = passed_in</h1>", rendered, rendered)
-        self.assertIn("<h1>Uniquely named variable = passed_in</h1>", rendered, rendered)
-        self.assertNotIn("<h1>Shadowing variable = NOT SHADOWED</h1>", rendered, rendered)
+        self.assertHTMLEqual(
+            rendered,
+            """
+            <div>
+                <h1>Parent content</h1>
+                <h1>Shadowing variable = passed_in</h1>
+                <h1>Uniquely named variable = unique_val</h1>
+            </div>
+            <div>
+                <h2>Slot content</h2>
+                <h1>Shadowing variable = slot_default_override</h1>
+                <h1>Uniquely named variable = passed_in</h1>
+            </div>
+            """
+        )
+
+    @override_settings(
+        COMPONENTS={
+            "context_behavior": "isolated",
+        }
+    )
+    def test_parent_args_can_be_drawn_from_context__isolated(self):
+        template = Template("""
+            {% load component_tags %}{% component_dependencies %}
+            {% component 'parent_with_args' parent_value=parent_value %}
+            {% endcomponent %}
+        """)
+        rendered = template.render(Context({"parent_value": "passed_in"}))
+
+        self.assertHTMLEqual(
+            rendered,
+            """
+            <div>
+                <h1>Parent content</h1>
+                <h1>Shadowing variable = passed_in</h1>
+                <h1>Uniquely named variable = unique_val</h1>
+            </div>
+            <div>
+                <h2>Slot content</h2>
+                <h1>Shadowing variable = slot_default_override</h1>
+                <h1>Uniquely named variable = passed_in</h1>
+            </div>
+            """
+        )
 
     def test_parent_args_available_outside_slots(self):
         template = Template(
@@ -236,7 +282,12 @@ class ParentArgsTests(BaseTestCase):
         self.assertIn("<h1>Uniquely named variable = passed_in</h1>", rendered, rendered)
         self.assertNotIn("<h1>Shadowing variable = NOT SHADOWED</h1>", rendered, rendered)
 
-    def test_parent_args_available_in_slots(self):
+    @override_settings(
+        COMPONENTS={
+            "context_behavior": "django",
+        }
+    )
+    def test_parent_args_available_in_slots__django(self):
         template = Template(
             """
             {% load component_tags %}{% component_dependencies %}
@@ -246,13 +297,56 @@ class ParentArgsTests(BaseTestCase):
                     {% endcomponent %}
                 {% endfill %}
             {% endcomponent %}
-        """  # NOQA
+            """
         )
         rendered = template.render(Context())
+        self.assertHTMLEqual(
+            rendered,
+            """
+            <div>
+                <h1>Parent content</h1>
+                <h1>Shadowing variable = passed_in</h1>
+                <h1>Uniquely named variable = unique_val</h1>
+            </div>
+            <div>
+                <h1>Shadowing variable = value_from_slot</h1>
+                <h1>Uniquely named variable = passed_in</h1>            
+            </div>
+            """
+        )
 
-        self.assertIn("<h1>Shadowing variable = value_from_slot</h1>", rendered, rendered)
-        self.assertIn("<h1>Uniquely named variable = passed_in</h1>", rendered, rendered)
-        self.assertNotIn("<h1>Shadowing variable = NOT SHADOWED</h1>", rendered, rendered)
+    @override_settings(
+        COMPONENTS={
+            "context_behavior": "isolated",
+        }
+    )
+    def test_parent_args_not_available_in_slots__isolated(self):
+        template = Template(
+            """
+            {% load component_tags %}{% component_dependencies %}
+            {% component 'parent_with_args' parent_value='passed_in' %}
+                {% fill 'content' %}
+                    {% component name='variable_display' shadowing_variable='value_from_slot' new_variable=inner_parent_value %}
+                    {% endcomponent %}
+                {% endfill %}
+            {% endcomponent %}
+            """
+        )
+        rendered = template.render(Context())
+        self.assertHTMLEqual(
+            rendered,
+            """
+            <div>
+                <h1>Parent content</h1>
+                <h1>Shadowing variable = passed_in</h1>
+                <h1>Uniquely named variable = unique_val</h1>
+            </div>
+            <div>
+                <h1>Shadowing variable = value_from_slot</h1>
+                <h1>Uniquely named variable = </h1>            
+            </div>
+            """
+        )
 
 
 class ContextCalledOnceTests(BaseTestCase):
@@ -325,13 +419,37 @@ class ComponentsCanAccessOuterContext(BaseTestCase):
         super().setUpClass()
         component.registry.register(name="simple_component", component=SimpleComponent)
 
-    def test_simple_component_can_use_outer_context(self):
+    @override_settings(
+        COMPONENTS={"context_behavior": "django"},
+    )
+    def test_simple_component_can_use_outer_context__django(self):
         template = Template(
             "{% load component_tags %}{% component_dependencies %}"
             "{% component 'simple_component' %}{% endcomponent %}"
         )
-        rendered = template.render(Context({"variable": "outer_value"})).strip()
-        self.assertIn("outer_value", rendered, rendered)
+        rendered = template.render(Context({"variable": "outer_value"}))
+        self.assertHTMLEqual(
+            rendered,
+            """
+            Variable: <strong> outer_value </strong>
+            """
+        )
+
+    @override_settings(
+        COMPONENTS={"context_behavior": "isolated"},
+    )
+    def test_simple_component_cannot_use_outer_context__isolated(self):
+        template = Template(
+            "{% load component_tags %}{% component_dependencies %}"
+            "{% component 'simple_component' %}{% endcomponent %}"
+        )
+        rendered = template.render(Context({"variable": "outer_value"}))
+        self.assertHTMLEqual(
+            rendered,
+            """
+            Variable: <strong> </strong>
+            """
+        )
 
 
 class IsolatedContextTests(BaseTestCase):
@@ -424,9 +542,9 @@ class OuterContextPropertyTests(BaseTestCase):
         component.registry.register(name="outer_context_component", component=OuterContextComponent)
 
     @override_settings(
-        COMPONENTS={"context_behavior": "global"},
+        COMPONENTS={"context_behavior": "django"},
     )
-    def test_outer_context_property_with_component_global(self):
+    def test_outer_context_property_with_component__django(self):
         template = Template(
             "{% load component_tags %}{% component_dependencies %}"
             "{% component 'outer_context_component' only %}{% endcomponent %}"
@@ -437,7 +555,7 @@ class OuterContextPropertyTests(BaseTestCase):
     @override_settings(
         COMPONENTS={"context_behavior": "isolated"},
     )
-    def test_outer_context_property_with_component_isolated(self):
+    def test_outer_context_property_with_component__isolated(self):
         template = Template(
             "{% load component_tags %}{% component_dependencies %}"
             "{% component 'outer_context_component' only %}{% endcomponent %}"

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -13,6 +13,7 @@ from .testutils import BaseTestCase
 
 import django_components
 import django_components.component_registry
+from django_components.component import safe_resolve_dict, safe_resolve_list
 from django_components import component
 
 
@@ -266,7 +267,46 @@ class ComponentSlottedTemplateTagTest(BaseTestCase):
         """,
         )
 
-    def test_slotted_template_with_context_var(self):
+    @override_settings(
+        COMPONENTS={"context_behavior": "isolated"}
+    )
+    def test_slotted_template_with_context_var__isolated(self):
+        component.registry.register(name="test1", component=SlottedComponentWithContext)
+
+        template = Template(
+            """
+            {% load component_tags %}
+            {% with my_first_variable="test123" %}
+                {% component "test1" variable="test456" %}
+                    {% fill "main" %}
+                        {{ my_first_variable }} - {{ variable }}
+                    {% endfill %}
+                    {% fill "footer" %}
+                        {{ my_second_variable }}
+                    {% endfill %}
+                {% endcomponent %}
+            {% endwith %}
+        """
+        )
+        rendered = template.render(Context({"my_second_variable": "test321"}))
+
+        self.assertHTMLEqual(
+            rendered,
+            """
+            <custom-template>
+                <header>Default header</header>
+                <main>test123 - </main>
+                <footer>test321</footer>
+            </custom-template>
+        """,
+        )
+
+    @override_settings(
+        COMPONENTS={
+            "context_behavior": "django",
+        }
+    )    
+    def test_slotted_template_with_context_var__django(self):
         component.registry.register(name="test1", component=SlottedComponentWithContext)
 
         template = Template(
@@ -739,11 +779,13 @@ class NestedSlotTests(BaseTestCase):
         rendered = template.render(Context({}))
         self.assertHTMLEqual(rendered, '<div id="outer">Default</div>')
 
-    def test_inner_slot_overriden(self):
+    def test_inner_slot_overriden(self):      
         template = Template(
             """
             {% load component_tags %}
-            {% component 'test' %}{% fill 'inner' %}Override{% endfill %}{% endcomponent %}
+            {% component 'test' %}
+                {% fill 'inner' %}Override{% endfill %}
+            {% endcomponent %}
         """
         )
         rendered = template.render(Context({}))
@@ -1045,7 +1087,10 @@ class ComponentNestingTests(BaseTestCase):
         super().tearDownClass()
         component.registry.clear()
 
-    def test_component_nesting_component_without_fill(self):
+    @override_settings(
+        COMPONENTS={"context_behavior": "django"}
+    )
+    def test_component_nesting_component_without_fill__django(self):
         template = Template(
             """
             {% load component_tags %}
@@ -1073,12 +1118,9 @@ class ComponentNestingTests(BaseTestCase):
         self.assertHTMLEqual(rendered, expected)
 
     @override_settings(
-        COMPONENTS={
-            "context_behavior": "isolated",
-            "slot_context_behavior": "isolated",
-        }
+        COMPONENTS={"context_behavior": "isolated"}
     )
-    def test_component_nesting_slot_inside_component_fill_isolated(self):
+    def test_component_nesting_component_without_fill__isolated(self):
         template = Template(
             """
             {% load component_tags %}
@@ -1103,12 +1145,36 @@ class ComponentNestingTests(BaseTestCase):
         self.assertHTMLEqual(rendered, expected)
 
     @override_settings(
-        COMPONENTS={
-            "context_behavior": "isolated",
-            "slot_context_behavior": "isolated",
-        }
+        COMPONENTS={"context_behavior": "isolated"}
     )
-    def test_component_nesting_slot_inside_component_fill_isolated_2(self):
+    def test_component_nesting_slot_inside_component_fill__isolated(self):
+        template = Template(
+            """
+            {% load component_tags %}
+            {% component "dashboard" %}{% endcomponent %}
+            """
+        )
+        rendered = template.render(Context({"items": [1, 2, 3]}))
+        expected = """
+        <div class="dashboard-component">
+          <div class="calendar-component">
+            <h1>
+              Welcome to your dashboard!
+            </h1>
+            <main>
+              Here are your to-do items for today:
+            </main>
+          </div>
+          <ol>
+          </ol>
+        </div>
+        """
+        self.assertHTMLEqual(rendered, expected)
+
+    @override_settings(
+        COMPONENTS={"context_behavior": "isolated"}
+    )
+    def test_component_nesting_slot_inside_component_fill__isolated_2(self):
         template = Template(
             """
             {% load component_tags %}
@@ -1137,12 +1203,9 @@ class ComponentNestingTests(BaseTestCase):
         self.assertHTMLEqual(rendered, expected)
 
     @override_settings(
-        COMPONENTS={
-            "context_behavior": "isolated",
-            "slot_context_behavior": "isolated",
-        }
+        COMPONENTS={"context_behavior": "isolated"}
     )
-    def test_component_nesting_deep_slot_inside_component_fill_isolated(self):
+    def test_component_nesting_deep_slot_inside_component_fill__isolated(self):
 
         template = Template(
             """
@@ -1166,7 +1229,10 @@ class ComponentNestingTests(BaseTestCase):
         """
         self.assertHTMLEqual(rendered, expected)
 
-    def test_component_nesting_component_with_fill_and_super(self):
+    @override_settings(
+        COMPONENTS={"context_behavior": "django"}
+    )
+    def test_component_nesting_component_with_fill_and_super__django(self):
         template = Template(
             """
             {% load component_tags %}
@@ -1189,6 +1255,35 @@ class ComponentNestingTests(BaseTestCase):
           <ol>
             <li>1</li>
             <li>2</li>
+          </ol>
+        </div>
+        """
+        self.assertHTMLEqual(rendered, expected)
+
+    @override_settings(
+        COMPONENTS={"context_behavior": "isolated"}
+    )
+    def test_component_nesting_component_with_fill_and_super__isolated(self):
+        template = Template(
+            """
+            {% load component_tags %}
+            {% component "dashboard" %}
+              {% fill "header" as "h" %} Hello! {{ h.default }} {% endfill %}
+            {% endcomponent %}
+            """
+        )
+        rendered = template.render(Context({"items": [1, 2]}))
+        expected = """
+        <div class="dashboard-component">
+          <div class="calendar-component">
+            <h1>
+              Hello! Welcome to your dashboard!
+            </h1>
+            <main>
+              Here are your to-do items for today:
+            </main>
+          </div>
+          <ol>
           </ol>
         </div>
         """
@@ -1235,7 +1330,10 @@ class ConditionalIfFilledSlotsTests(BaseTestCase):
         rendered = Template(template).render(Context({}))
         self.assertHTMLEqual(rendered, expected)
 
-    def test_component_with_filled_conditional_slot(self):
+    @override_settings(
+        COMPONENTS={"context_behavior": "django"}
+    )
+    def test_component_with_filled_conditional_slot__django(self):
         template = """
         {% load component_tags %}
         {% component "conditional_slots" %}
@@ -1311,6 +1409,38 @@ class ConditionalIfFilledSlotsTests(BaseTestCase):
         self.assertHTMLEqual(rendered, expected)
 
 
+class ContextVarsTests(BaseTestCase):
+    class IsFilledVarsComponent(component.Component):
+        template_name = "template_is_filled.html"
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+        component.registry.register("is_filled_vars", cls.IsFilledVarsComponent)
+
+    def test_is_filled_vars(self):
+        template = """
+            {% load component_tags %}
+            {% component "is_filled_vars" %}
+                {% fill "title" %}{% endfill %}
+                {% fill "my-title-2" %}{% endfill %}
+                {% fill "escape this: #$%^*()" %}{% endfill %}
+            {% endcomponent %}
+        """
+        rendered = Template(template).render(Context())
+        # NOTE: `&#x27;` are escaped quotes
+        expected = """
+            <div class="frontmatter-component">
+                {&#x27;title&#x27;: True,
+                &#x27;my_title&#x27;: False,
+                &#x27;my_title_1&#x27;: False,
+                &#x27;my_title_2&#x27;: True,
+                &#x27;escape_this_________&#x27;: True}
+            </div>
+        """
+        self.assertHTMLEqual(rendered, expected)
+
+
 class RegressionTests(BaseTestCase):
     """Ensure we don't break the same thing AGAIN."""
 
@@ -1372,7 +1502,10 @@ class IterationFillTest(BaseTestCase):
     def setUp(self):
         django_components.component.registry.clear()
 
-    def test_inner_slot_iteration_basic(self):
+    @override_settings(
+        COMPONENTS={"context_behavior": "django"}
+    )
+    def test_inner_slot_iteration_basic__django(self):
         component.registry.register("slot_in_a_loop", self.ComponentSimpleSlotInALoop)
 
         template = Template(
@@ -1396,7 +1529,31 @@ class IterationFillTest(BaseTestCase):
             """,
         )
 
-    def test_inner_slot_iteration_with_variable_from_outer_scope(self):
+    @override_settings(
+        COMPONENTS={"context_behavior": "isolated"}
+    )
+    def test_inner_slot_iteration_basic__isolated(self):
+        component.registry.register("slot_in_a_loop", self.ComponentSimpleSlotInALoop)
+
+        template = Template(
+            """
+            {% load component_tags %}
+            {% component "slot_in_a_loop" objects=objects %}
+                {% fill "slot_inner" %}
+                    {{ object }}
+                {% endfill %}
+            {% endcomponent %}
+        """
+        )
+        objects = ["OBJECT1", "OBJECT2"]
+        rendered = template.render(Context({"objects": objects}))
+
+        self.assertHTMLEqual(rendered, "")
+
+    @override_settings(
+        COMPONENTS={"context_behavior": "django"}
+    )
+    def test_inner_slot_iteration_with_variable_from_outer_scope__django(self):
         component.registry.register("slot_in_a_loop", self.ComponentSimpleSlotInALoop)
 
         template = Template(
@@ -1430,7 +1587,45 @@ class IterationFillTest(BaseTestCase):
             """,
         )
 
-    def test_inner_slot_iteration_nested(self):
+    @override_settings(
+        COMPONENTS={"context_behavior": "isolated"}
+    )
+    def test_inner_slot_iteration_with_variable_from_outer_scope__isolated(self):
+        component.registry.register("slot_in_a_loop", self.ComponentSimpleSlotInALoop)
+
+        template = Template(
+            """
+            {% load component_tags %}
+            {% component "slot_in_a_loop" objects=objects %}
+                {% fill "slot_inner" %}
+                    {{ outer_scope_variable }}
+                    {{ object }}
+                {% endfill %}
+            {% endcomponent %}
+        """
+        )
+        objects = ["OBJECT1", "OBJECT2"]
+        rendered = template.render(
+            Context(
+                {
+                    "objects": objects,
+                    "outer_scope_variable": "OUTER_SCOPE_VARIABLE",
+                }
+            )
+        )
+
+        self.assertHTMLEqual(
+            rendered,
+            """
+            OUTER_SCOPE_VARIABLE
+            OUTER_SCOPE_VARIABLE
+            """,
+        )
+
+    @override_settings(
+        COMPONENTS={"context_behavior": "django"}
+    )
+    def test_inner_slot_iteration_nested__django(self):
         component.registry.register("slot_in_a_loop", self.ComponentSimpleSlotInALoop)
 
         objects = [
@@ -1464,7 +1659,39 @@ class IterationFillTest(BaseTestCase):
             """,
         )
 
-    def test_inner_slot_iteration_nested_with_outer_scope_variable(self):
+    @override_settings(
+        COMPONENTS={"context_behavior": "isolated"}
+    )
+    def test_inner_slot_iteration_nested__isolated(self):
+        component.registry.register("slot_in_a_loop", self.ComponentSimpleSlotInALoop)
+
+        objects = [
+            {"inner": ["ITER1_OBJ1", "ITER1_OBJ2"]},
+            {"inner": ["ITER2_OBJ1", "ITER2_OBJ2"]},
+        ]
+
+        template = Template(
+            """
+            {% load component_tags %}
+            {% component "slot_in_a_loop" objects=objects %}
+                {% fill "slot_inner" %}
+                    {% component "slot_in_a_loop" objects=object.inner %}
+                        {% fill "slot_inner" %}
+                            {{ object }}
+                        {% endfill %}
+                    {% endcomponent %}
+                {% endfill %}
+            {% endcomponent %}
+        """
+        )
+        rendered = template.render(Context({"objects": objects}))
+
+        self.assertHTMLEqual(rendered, "")
+
+    @override_settings(
+        COMPONENTS={"context_behavior": "django"}
+    )
+    def test_inner_slot_iteration_nested_with_outer_scope_variable__django(self):
         component.registry.register("slot_in_a_loop", self.ComponentSimpleSlotInALoop)
 
         objects = [
@@ -1514,7 +1741,55 @@ class IterationFillTest(BaseTestCase):
             """,
         )
 
-    def test_inner_slot_iteration_nested_with_slot_default(self):
+    @override_settings(
+        COMPONENTS={"context_behavior": "isolated"}
+    )
+    def test_inner_slot_iteration_nested_with_outer_scope_variable__isolated(self):
+        component.registry.register("slot_in_a_loop", self.ComponentSimpleSlotInALoop)
+
+        objects = [
+            {"inner": ["ITER1_OBJ1", "ITER1_OBJ2"]},
+            {"inner": ["ITER2_OBJ1", "ITER2_OBJ2"]},
+        ]
+
+        template = Template(
+            """
+            {% load component_tags %}
+            {% component "slot_in_a_loop" objects=objects %}
+                {% fill "slot_inner" %}
+                    {{ outer_scope_variable_1 }}
+                    {% component "slot_in_a_loop" objects=object.inner %}
+                        {% fill "slot_inner" %}
+                            {{ outer_scope_variable_2 }}
+                            {{ object }}
+                        {% endfill %}
+                    {% endcomponent %}
+                {% endfill %}
+            {% endcomponent %}
+        """
+        )
+        rendered = template.render(
+            Context(
+                {
+                    "objects": objects,
+                    "outer_scope_variable_1": "OUTER_SCOPE_VARIABLE1",
+                    "outer_scope_variable_2": "OUTER_SCOPE_VARIABLE2",
+                }
+            )
+        )
+
+        self.assertHTMLEqual(
+            rendered,
+            """
+            OUTER_SCOPE_VARIABLE1
+            OUTER_SCOPE_VARIABLE1
+            """,
+        )
+
+    @override_settings(
+        COMPONENTS={"context_behavior": "django"}
+    )
+    def test_inner_slot_iteration_nested_with_slot_default__django(self):
         component.registry.register("slot_in_a_loop", self.ComponentSimpleSlotInALoop)
 
         objects = [
@@ -1548,7 +1823,38 @@ class IterationFillTest(BaseTestCase):
             """,
         )
 
-    def test_inner_slot_iteration_nested_with_slot_default_and_outer_scope_variable(
+    @override_settings(
+        COMPONENTS={"context_behavior": "isolated"}
+    )
+    def test_inner_slot_iteration_nested_with_slot_default__isolated(self):
+        component.registry.register("slot_in_a_loop", self.ComponentSimpleSlotInALoop)
+
+        objects = [
+            {"inner": ["ITER1_OBJ1", "ITER1_OBJ2"]},
+            {"inner": ["ITER2_OBJ1", "ITER2_OBJ2"]},
+        ]
+
+        template = Template(
+            """
+            {% load component_tags %}
+            {% component "slot_in_a_loop" objects=objects %}
+                {% fill "slot_inner" %}
+                    {% component "slot_in_a_loop" objects=object.inner %}
+                        {% fill "slot_inner" as "super_slot_inner" %}
+                            {{ super_slot_inner.default }}
+                        {% endfill %}
+                    {% endcomponent %}
+                {% endfill %}
+            {% endcomponent %}
+        """
+        )
+        rendered = template.render(Context({"objects": objects}))
+        self.assertHTMLEqual(rendered, "")
+
+    @override_settings(
+        COMPONENTS={"context_behavior": "django"}
+    )
+    def test_inner_slot_iteration_nested_with_slot_default_and_outer_scope_variable__django(
         self,
     ):
         component.registry.register("slot_in_a_loop", self.ComponentSimpleSlotInALoop)
@@ -1597,5 +1903,113 @@ class IterationFillTest(BaseTestCase):
             ITER2_OBJ1 default
             OUTER_SCOPE_VARIABLE2
             ITER2_OBJ2 default
+            """,
+        )
+
+    @override_settings(
+        COMPONENTS={"context_behavior": "isolated"}
+    )
+    def test_inner_slot_iteration_nested_with_slot_default_and_outer_scope_variable__isolated_1(
+        self,
+    ):
+        component.registry.register("slot_in_a_loop", self.ComponentSimpleSlotInALoop)
+
+        objects = [
+            {"inner": ["ITER1_OBJ1", "ITER1_OBJ2"]},
+            {"inner": ["ITER2_OBJ1", "ITER2_OBJ2"]},
+        ]
+
+        # NOTE: In this case the `object.inner` in the inner "slot_in_a_loop"
+        # should be undefined, so the loop inside the inner `slot_in_a_loop`
+        # shouldn't run. Hence even the inner `slot_inner` fill should NOT run.
+        template = Template(
+            """
+            {% load component_tags %}
+            {% component "slot_in_a_loop" objects=objects %}
+                {% fill "slot_inner" %}
+                    {{ outer_scope_variable_1 }}
+                    {% component "slot_in_a_loop" objects=object.inner %}
+                        {% fill "slot_inner" as "super_slot_inner" %}
+                            {{ outer_scope_variable_2 }}
+                            {{ super_slot_inner.default }}
+                        {% endfill %}
+                    {% endcomponent %}
+                {% endfill %}
+            {% endcomponent %}
+        """
+        )
+        rendered = template.render(
+            Context(
+                {
+                    "objects": objects,
+                    "outer_scope_variable_1": "OUTER_SCOPE_VARIABLE1",
+                    "outer_scope_variable_2": "OUTER_SCOPE_VARIABLE2",
+                }
+            )
+        )
+
+        self.assertHTMLEqual(
+            rendered,
+            """
+            OUTER_SCOPE_VARIABLE1
+            OUTER_SCOPE_VARIABLE1
+            """,
+        )
+
+    @override_settings(
+        COMPONENTS={"context_behavior": "isolated"}
+    )
+    def test_inner_slot_iteration_nested_with_slot_default_and_outer_scope_variable__isolated_2(
+        self,
+    ):
+        component.registry.register("slot_in_a_loop", self.ComponentSimpleSlotInALoop)
+
+        objects = [
+            {"inner": ["ITER1_OBJ1", "ITER1_OBJ2"]},
+            {"inner": ["ITER2_OBJ1", "ITER2_OBJ2"]},
+        ]
+
+        # NOTE: In this case we use `objects` in the inner "slot_in_a_loop", which
+        # is defined in the root context. So the loop inside the inner `slot_in_a_loop`
+        # should run.
+        template = Template(
+            """
+            {% load component_tags %}
+            {% component "slot_in_a_loop" objects=objects %}
+                {% fill "slot_inner" %}
+                    {{ outer_scope_variable_1 }}
+                    {% component "slot_in_a_loop" objects=objects %}
+                        {% fill "slot_inner" as "super_slot_inner" %}
+                            {{ outer_scope_variable_2 }}
+                            {{ super_slot_inner.default }}
+                        {% endfill %}
+                    {% endcomponent %}
+                {% endfill %}
+            {% endcomponent %}
+        """
+        )
+        rendered = template.render(
+            Context(
+                {
+                    "objects": objects,
+                    "outer_scope_variable_1": "OUTER_SCOPE_VARIABLE1",
+                    "outer_scope_variable_2": "OUTER_SCOPE_VARIABLE2",
+                }
+            )
+        )
+
+        self.assertHTMLEqual(
+            rendered,
+            """
+            OUTER_SCOPE_VARIABLE1
+            OUTER_SCOPE_VARIABLE2
+            {&#x27;inner&#x27;: [&#x27;ITER1_OBJ1&#x27;, &#x27;ITER1_OBJ2&#x27;]} default
+            OUTER_SCOPE_VARIABLE2
+            {&#x27;inner&#x27;: [&#x27;ITER2_OBJ1&#x27;, &#x27;ITER2_OBJ2&#x27;]} default
+            OUTER_SCOPE_VARIABLE1
+            OUTER_SCOPE_VARIABLE2
+            {&#x27;inner&#x27;: [&#x27;ITER1_OBJ1&#x27;, &#x27;ITER1_OBJ2&#x27;]} default
+            OUTER_SCOPE_VARIABLE2
+            {&#x27;inner&#x27;: [&#x27;ITER2_OBJ1&#x27;, &#x27;ITER2_OBJ2&#x27;]} default
             """,
         )

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -941,7 +941,6 @@ class TemplateSyntaxErrorTests(BaseTestCase):
         super().setUpClass()
         component.registry.register("test", SlottedComponent)
         component.registry.register("broken_component", BrokenComponent)
-        component.registry.register("nonunique_slot_component", NonUniqueSlotsComponent)
 
     @classmethod
     def tearDownClass(cls) -> None:
@@ -1027,16 +1026,6 @@ class TemplateSyntaxErrorTests(BaseTestCase):
                 {% component "broken_component" %}
                     {% fill "header" %}Custom header {% endfill %}
                     {% fill "header" %}Other header{% endfill %}
-                {% endcomponent %}
-                """
-            ).render(Context({}))
-
-    def test_non_unique_slot_names_is_error(self):
-        with self.assertRaises(TemplateSyntaxError):
-            Template(
-                """
-                {% load component_tags %}
-                {% component "nonunique_slot_component" %}
                 {% endcomponent %}
                 """
             ).render(Context({}))


### PR DESCRIPTION
This MR removes the nodes and template tags involved in the If/Elif/Else logic. Instead, the context is populated with a `slots` dict that tracks which slots have been filled, and can be used like `{% if slots.header %}`

TODO:
- [ ] Update README
- [ ] Document deprecation of IfNodes, and their replacement with `slots` context var
- [ ] Document that since the version in which this would be published (e.g. v0.69), the slot names need to be valid Python identifiers

Closes https://github.com/EmilStenstrom/django-components/issues/280