### PR TITLE
Send discord notification on new issue

### DIFF
--- a/.github/workflows/issue-to-discord.yml
+++ b/.github/workflows/issue-to-discord.yml
@@ -1,0 +1,35 @@
+name: Notify Discord on new issues
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post to Discord (development channel)
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_DEVELOPMENT }}
+        run: |
+          payload=$(jq -n --arg title "${{ github.event.issue.title }}" \
+                        --arg url "${{ github.event.issue.html_url }}" \
+                        --arg user "${{ github.event.issue.user.login }}" \
+                        --arg repo "${{ github.repository }}" \
+                        --arg number "#${{ github.event.issue.number }}" \
+                        '{
+                          "username": "GitHub Issues",
+                          "avatar_url": "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png",
+                          "embeds": [
+                            {
+                              "title": "New issue: \($number) \($title)",
+                              "url": \($url),
+                              "color": 3447003,
+                              "author": {"name": \($user)},
+                              "footer": {"text": \($repo)},
+                              "timestamp": "${{ github.event.issue.created_at }}"
+                            }
+                          ]
+                        }')
+
+          curl -sS -X POST -H "Content-Type: application/json" -d "$payload" "$DISCORD_WEBHOOK_URL" | cat


### PR DESCRIPTION
Add a GitHub Actions workflow to notify Discord when a new issue is opened.

---
<a href="https://cursor.com/background-agent?bcId=bc-e282a7cf-9fc7-427c-9d2a-bad639f7aeb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e282a7cf-9fc7-427c-9d2a-bad639f7aeb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

